### PR TITLE
Fix typo in utils

### DIFF
--- a/it_management/utils.py
+++ b/it_management/utils.py
@@ -288,7 +288,13 @@ def for_every_customer_create_default_landscape():
 				print("Inserted " + str(doc.title))
 			except Exception as ex:
 				#Check  duplicate (TODO is probably unnessecary)
-				dups = frappe.db.get_call('Customer',filters={'customer_name':c["customer_name"]}, fields=['name'], page_length=10000,as_list=False)
+				dups = frappe.db.get_all(
+					'Customer',
+					filters={'customer_name': c["customer_name"]},
+					fields=['name'],
+					page_length=10000,
+					as_list=False,
+				)
 				print("Exception Duplicate Customer: " + str(dups))
 				if(len(dups) > 1):
 					pass


### PR DESCRIPTION
## Summary
- correct typo in `for_every_customer_create_default_landscape`
- keep indentation consistent

## Testing
- `python -m py_compile it_management/utils.py`

------
https://chatgpt.com/codex/tasks/task_e_685eeae0ae2c8325a5aa9815cb6fd9c1