### PR TITLE
Add User Account Type creation test

### DIFF
--- a/it_management/it_management/doctype/user_account_type/test_user_account_type.py
+++ b/it_management/it_management/doctype/user_account_type/test_user_account_type.py
@@ -3,8 +3,22 @@
 # See license.txt
 from __future__ import unicode_literals
 
-# import frappe
-import unittest
+import frappe
+from frappe.tests.utils import FrappeTestCase
 
-class TestUserAccountType(unittest.TestCase):
-	pass
+
+class TestUserAccountType(FrappeTestCase):
+    def test_user_account_type_creation(self):
+        doc = frappe.get_doc(
+            {
+                "doctype": "User Account Type",
+                "title": "Test Account Type",
+            }
+        )
+        doc.insert()
+
+        self.assertTrue(
+            frappe.db.exists("User Account Type", {"title": "Test Account Type"})
+        )
+
+        doc.delete()


### PR DESCRIPTION
## Summary
- use FrappeTestCase for User Account Type tests
- add test that creates a minimal User Account Type

## Testing
- `pytest it_management/it_management/doctype/user_account_type/test_user_account_type.py -q` *(fails: ModuleNotFoundError: No module named 'frappe.tests')*


------
https://chatgpt.com/codex/tasks/task_e_689bb3def2488325af0abf9639f7ac47